### PR TITLE
Fixed steamcmd call for beta

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ if [[ "$SKIPUPDATE" == "false" ]]; then
 
     printf "Downloading the latest version of the game...\\n"
 
-    /home/steam/steamcmd/steamcmd.sh +force_install_dir /config/gamefiles +login anonymous +app_update "$STEAMAPPID$STEAMBETAFLAG" +quit
+    /home/steam/steamcmd/steamcmd.sh +force_install_dir /config/gamefiles +login anonymous +app_update $STEAMAPPID$STEAMBETAFLAG +quit
 else
     printf "Skipping update as flag is set\\n"
 fi


### PR DESCRIPTION
this quote marks around $STEAMAPPID$STEAMBETAFLAG were causing it to not download the experimental branch correctly; this rectifies that